### PR TITLE
ci: add tests for Windows and macOS

### DIFF
--- a/.github/workflows/test_unix.yaml
+++ b/.github/workflows/test_unix.yaml
@@ -4,16 +4,14 @@ on:
       - master
   pull_request:
 
-name: Tests
+name: Tests on UNIX
 jobs:
   test:
     name: Rust tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust:
-          - stable
-          - nightly
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - name: Checkout source code
@@ -24,7 +22,7 @@ jobs:
       - name: Use stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           profile: minimal
           override: true
 

--- a/.github/workflows/test_windows.yaml
+++ b/.github/workflows/test_windows.yaml
@@ -1,0 +1,38 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+name: Tests on Windows
+jobs:
+  test:
+    name: Rust tests
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        target: [x86_64-pc-windows-gnu] # Not running `x86_64-pc-windows-msvc` for now
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Use stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          profile: minimal
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
+
+      - name: Run cargo tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --target ${{ matrix.target }}


### PR DESCRIPTION
This PR adds Windows and macOS testing to CI pipelines.

Note that currently `x86_64-pc-windows-msvc` is not tested as it's [not supported](https://github.com/xJonathanLEI/starkware-crypto-rs/issues/3) yet.