### PR TITLE
release: bump version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "starkware-crypto-sys"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "cc",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starkware-crypto-sys"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Jonathan LEI <me@xjonathan.dev>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
Bumps version to v0.1.3 for publishing on crates.io.